### PR TITLE
fix: register non-null response

### DIFF
--- a/backend/src/main/java/com/workorbit/backend/Auth/Service/AuthService.java
+++ b/backend/src/main/java/com/workorbit/backend/Auth/Service/AuthService.java
@@ -43,21 +43,8 @@ public class AuthService {
         String token = jwtService.generateToken(userDetails);
 
         AppUserDetails appUserDetails = (AppUserDetails) userDetails;
-        String name = appUserDetails.getName();
-        String email = appUserDetails.getUsername();
-        String role = appUserDetails.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .findFirst()
-                .orElse("UNKNOWN_ROLE");
 
-        AuthResponse authResponse = AuthResponse.builder()
-                .name(name)
-                .email(email)
-                .role(role)
-                .token(token)
-                .build();
-
-        return ApiResponse.success(authResponse);
+        return ApiResponse.success(createAuthResponse(appUserDetails, token));
     }
 
     public ApiResponse<AuthResponse> registerClient(RegistrationRequest request) {
@@ -94,14 +81,25 @@ public class AuthService {
         }
 
         AppUser savedUser = appUserRepository.save(appUser);
+        AppUserDetails appUserDetails = new AppUserDetails(savedUser);
 
         // generate a token for immediate login
         String token = jwtService.generateToken(new AppUserDetails(savedUser));
 
-        AuthResponse authResponse = AuthResponse.builder()
+        return ApiResponse.success(createAuthResponse(appUserDetails, token));
+    }
+
+    private AuthResponse createAuthResponse(AppUserDetails userDetails, String token) {
+        String role = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .findFirst()
+                .orElse("UNKNOWN_ROLE");
+
+        return AuthResponse.builder()
+                .name(userDetails.getName())
+                .email(userDetails.getUsername())
+                .role(role)
                 .token(token)
                 .build();
-
-        return ApiResponse.success(authResponse);
     }
 }


### PR DESCRIPTION
previously login worked correctly, but register gave null response
<img width="622" height="328" alt="image" src="https://github.com/user-attachments/assets/2b568e9c-1db6-491f-aae8-9b930b5b22fe" />
the implementation was missing, now it has been added
<img width="624" height="312" alt="image" src="https://github.com/user-attachments/assets/111b4561-a790-4ecc-bbac-3b0e758c9538" />
<img width="553" height="315" alt="image" src="https://github.com/user-attachments/assets/d7840c69-3b0f-446d-8644-74fdc97fb13b" />
<img width="612" height="303" alt="image" src="https://github.com/user-attachments/assets/2e6ea9e9-837f-4b2e-a7af-157a8282fbab" />
