### PR TITLE
feat: added id to auth response

### DIFF
--- a/backend/src/main/java/com/workorbit/backend/Auth/DTO/AppUserDetails.java
+++ b/backend/src/main/java/com/workorbit/backend/Auth/DTO/AppUserDetails.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 @Getter
 public class AppUserDetails implements UserDetails {
 
+    private final Long profileId;
     private final String username;
     private final String password;
     private final String name;
@@ -23,8 +24,10 @@ public class AppUserDetails implements UserDetails {
         this.password = appUser.getPassword();
         if (appUser.getRole() == Role.ROLE_CLIENT) {
             this.name = appUser.getClientProfile().getName();
+            this.profileId = appUser.getClientProfile().getId();
         } else {
             this.name = appUser.getFreelancerProfile().getName();
+            this.profileId = appUser.getFreelancerProfile().getId();
         }
         this.authorities = Collections.singletonList(new SimpleGrantedAuthority(appUser.getRole().toString()));
     }

--- a/backend/src/main/java/com/workorbit/backend/Auth/DTO/AuthResponse.java
+++ b/backend/src/main/java/com/workorbit/backend/Auth/DTO/AuthResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class AuthResponse {
 
+    private final Long id;
     private final String role;
     private final String name;
     private final String email;

--- a/backend/src/main/java/com/workorbit/backend/Auth/Service/AuthService.java
+++ b/backend/src/main/java/com/workorbit/backend/Auth/Service/AuthService.java
@@ -96,6 +96,7 @@ public class AuthService {
                 .orElse("UNKNOWN_ROLE");
 
         return AuthResponse.builder()
+                .id(userDetails.getProfileId())
                 .name(userDetails.getName())
                 .email(userDetails.getUsername())
                 .role(role)


### PR DESCRIPTION
- added the `id` field to the login and register responses for the respective client and freelancer